### PR TITLE
Fix totals in generated proforma invoices

### DIFF
--- a/app.py
+++ b/app.py
@@ -191,6 +191,8 @@ def process_all(df, start_num, config, upload_folder):
             })
             serials += [str(s) for s in prod_df['Сер. №']]
 
+        sum_base = sum(float(i['total']) for i in items)
+
         invoice_data = {
             "invoice_no": f"{invoice_no:09d}",
             "invoice_date": today,
@@ -211,6 +213,9 @@ def process_all(df, start_num, config, upload_folder):
             "firm_eik": config['invoice']['firm_eik'],
             "firm_address": config['invoice']['firm_address'],
             "firm_mol": config['invoice']['firm_mol'],
+            "sum_base": f"{sum_base:.2f}",
+            "vat_amount": f"{sum_base * 0.20:.2f}",
+            "total_amount": f"{sum_base * 1.20:.2f}",
         }
 
         # Генериране на PDF проформа

--- a/templates/invoice_template.html
+++ b/templates/invoice_template.html
@@ -49,9 +49,7 @@
             <th>Ед. цена (лв.)</th>
             <th>Стойност (лв.)</th>
         </tr>
-        {% set sum_base = 0 %}
         {% for item in items %}
-        {% set sum_base = sum_base + item.qty|float * item.price|float %}
         <tr>
             <td>{{ item.desc }}</td>
             <td>{{ item.qty }}</td>
@@ -61,15 +59,15 @@
         {% endfor %}
         <tr>
             <td colspan="3" class="totals">Данъчна основа 20%:</td>
-            <td class="totals">{{ '%.2f' % sum_base }}</td>
+            <td class="totals">{{ sum_base }}</td>
         </tr>
         <tr>
             <td colspan="3" class="totals">20% ДДС:</td>
-            <td class="totals">{{ '%.2f' % (sum_base * 0.20) }}</td>
+            <td class="totals">{{ vat_amount }}</td>
         </tr>
         <tr>
             <td colspan="3" class="totals">Общо:</td>
-            <td class="totals">{{ '%.2f' % (sum_base * 1.20) }}</td>
+            <td class="totals">{{ total_amount }}</td>
         </tr>
     </table>
     <div class="footer">


### PR DESCRIPTION
## Summary
- compute subtotal/VAT/total in Python instead of Jinja template
- display provided totals in invoice template

## Testing
- `python -m py_compile app.py utils.py`
- `flake8 app.py utils.py`
- manual run of `process_all` with sample data and check PDF output

------
https://chatgpt.com/codex/tasks/task_e_6885ce3099808320987b844158e0c17b