### PR TITLE
Add object name to transfer log

### DIFF
--- a/app.py
+++ b/app.py
@@ -320,7 +320,9 @@ def process_all(df, start_num, config, upload_folder):
                 "price": item['price'],
                 "code": item['code'],
                 "producer": item['producer'],
-                "date": today
+                "date": today,
+                "object_name": config.get('object', {}).get('name', 'Основен склад'),
+                "object_id": str(config.get('object', {}).get('id', ''))
             }
             transfer_ops.append(op)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,10 @@ invoice:
   firm_address: "Град, адрес..."
   firm_mol: "Вашето име"
 
+object:
+  id: 1
+  name: "Основен склад"
+
 instructions:
   default: "Примерна инструкция за плащане..."
   Daisy: "Указание за устройства Daisy..."

--- a/utils.py
+++ b/utils.py
@@ -41,12 +41,13 @@ def generate_transfer_log(ops_list, output_path):
         ET.SubElement(oper, 'operations_Acct').text = op['invoice_no']
         ET.SubElement(oper, 'operations_GoodID').text = op['code']
         ET.SubElement(oper, 'operations_PartnerID').text = ""   # ако има
-        ET.SubElement(oper, 'operations_ObjectID').text = ""
+        ET.SubElement(oper, 'operations_ObjectID').text = op.get('object_id', '')
         ET.SubElement(oper, 'operations_OperatorID').text = ""
         ET.SubElement(oper, 'operations_Qtty').text = str(op['qty'])
         ET.SubElement(oper, 'operations_PriceOut').text = op['price']
         ET.SubElement(oper, 'operations_Date').text = datetime.now().isoformat()
         ET.SubElement(oper, 'goods_Name').text = op['desc']
+        ET.SubElement(oper, 'objects_Name').text = op.get('object_name', '')
         # Допиши и други полета ако трябва
     # Кратко описание
     desc = ET.SubElement(root, 'Description')


### PR DESCRIPTION
## Summary
- include warehouse name from config when generating transfer log
- add config entries `object.id` and `object.name`

## Testing
- `python -m py_compile app.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688666ad837883209c87564481fdb0f2