### PR TITLE
Add object name to transfer log

### DIFF
--- a/app.py
+++ b/app.py
@@ -320,7 +320,9 @@ def process_all(df, start_num, config, upload_folder):
                 "price": item['price'],
                 "code": item['code'],
                 "producer": item['producer'],
-                "date": today
+                "date": today,
+                "object_name": config.get('object', {}).get('name', 'Основен склад'),
+                "object_id": str(config.get('object', {}).get('id', ''))
             }
             transfer_ops.append(op)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,10 @@ invoice:
   firm_address: "Град, адрес..."
   firm_mol: "Вашето име"
 
+object:
+  id: 1
+  name: "Основен склад"
+
 instructions:
   default: "Примерна инструкция за плащане..."
   Daisy: "Указание за устройства Daisy..."

--- a/utils.py
+++ b/utils.py
@@ -34,20 +34,147 @@ def generate_transfer_log(ops_list, output_path):
     Създава transfer.log (XML) със списък от операции.
     """
     root = ET.Element('Microinvest')
-    for op in ops_list:
+    for idx, op in enumerate(ops_list, start=1):
         oper = ET.SubElement(root, 'OperationsRelated')
-        ET.SubElement(oper, 'operations_ID').text = op['invoice_no']
-        ET.SubElement(oper, 'operations_OperType').text = "14"
-        ET.SubElement(oper, 'operations_Acct').text = op['invoice_no']
-        ET.SubElement(oper, 'operations_GoodID').text = op['code']
-        ET.SubElement(oper, 'operations_PartnerID').text = ""   # ако има
-        ET.SubElement(oper, 'operations_ObjectID').text = ""
-        ET.SubElement(oper, 'operations_OperatorID').text = ""
-        ET.SubElement(oper, 'operations_Qtty').text = str(op['qty'])
-        ET.SubElement(oper, 'operations_PriceOut').text = op['price']
-        ET.SubElement(oper, 'operations_Date').text = datetime.now().isoformat()
-        ET.SubElement(oper, 'goods_Name').text = op['desc']
-        # Допиши и други полета ако трябва
+
+        def add(tag, value=""):
+            ET.SubElement(oper, tag).text = str(value)
+
+        add('operations_ID', f"{op['invoice_no']}{idx}")
+        add('operations_OperType', "14")
+        add('operations_Acct', op['invoice_no'])
+        add('operations_GoodID', op['code'])
+        add('operations_PartnerID', op.get('partner_id', ""))
+        add('operations_ObjectID', op.get('object_id', ""))
+        add('operations_OperatorID', "")
+        add('operations_Qtty', op['qty'])
+        add('operations_Sign', "0")
+        add('operations_PriceIn', "0")
+        add('operations_PriceOut', op['price'])
+        vat_out = "{:.2f}".format(float(op['price']) * 0.2)
+        add('operations_VATIn', "0")
+        add('operations_VATOut', vat_out)
+        add('operations_Discount', "0")
+        add('operations_CurrencyID', "1")
+        add('operations_Date', datetime.now().isoformat())
+        add('operations_Lot', " ")
+        add('operations_LotID', "1")
+        add('operations_Note', " ")
+        add('operations_SrcDocID', "0")
+        add('operations_UserID', "2")
+        add('operations_UserRealTime', datetime.now().isoformat())
+
+        add('lots_ID', "1")
+        add('lots_SerialNo', "")
+        add('lots_Location', "")
+        add('lots_ProductionDate', "2002-01-01T00:00:00+02:00")
+        add('lots_EndDate', "2002-01-01T00:00:00+02:00")
+
+        add('goods_ID', op['code'])
+        add('goods_Code', op['code'])
+        add('goods_BarCode1', "")
+        add('goods_BarCode2', "")
+        add('goods_BarCode3', "")
+        add('goods_Catalog1', "")
+        add('goods_Catalog2', "")
+        add('goods_Catalog3', "")
+        add('goods_Name', op['desc'])
+        add('goods_Name2', op['desc'])
+        add('goods_Measure1', "бр.")
+        add('goods_Measure2', "бр.")
+        add('goods_Ratio', "1")
+        add('goods_PriceIn', "0")
+        add('goods_PriceOut1', "0")
+        add('goods_PriceOut2', op['price'])
+        for n in range(3, 11):
+            add(f'goods_PriceOut{n}', "0")
+        add('goods_MinQtty', "0")
+        add('goods_NormalQtty', "0")
+        add('goods_Description', "")
+        add('goods_Type', "0")
+        add('goods_IsRecipe', "0")
+        add('goods_TaxGroup', "1")
+        add('goods_IsVeryUsed', "0")
+        add('goods_GroupID', "502")
+        add('goods_Deleted', "0")
+
+        add('objects_ID', op.get('object_id', ""))
+        add('objects_Code', op.get('object_id', ""))
+        add('objects_Name', op.get('object_name', ""))
+        add('objects_Name2', op.get('object_name', ""))
+        add('objects_IsVeryUsed', "-1")
+        add('objects_GroupID', "1")
+        add('objects_PriceGroup', "1")
+        add('objects_Deleted', "0")
+
+        add('partners_ID', op.get('partner_id', ""))
+        add('partners_Code', "")
+        add('partners_Company', op['client'])
+        add('partners_Company2', op['client'])
+        add('partners_MOL', "")
+        add('partners_MOL2', "")
+        add('partners_City', "")
+        add('partners_City2', "")
+        add('partners_Address', "")
+        add('partners_Address2', "")
+        add('partners_Phone', "")
+        add('partners_Phone2', "")
+        add('partners_Fax', "")
+        add('partners_eMail', "")
+        add('partners_TaxNo', op.get('eik', ""))
+        add('partners_Bulstat', op.get('eik', ""))
+        add('Partners_BankName', "")
+        add('partners_BankCode', "")
+        add('partners_BankAcct', "")
+        add('partners_BankVATName', "")
+        add('partners_BankVATCode', "")
+        add('partners_BankVATAcct', "")
+        add('partners_PriceGroup', "1")
+        add('partners_Discount', "0")
+        add('partners_Type', "0")
+        add('partners_IsVeryUsed', "0")
+        add('partners_UserID', "1")
+        add('partners_GroupID', "301")
+        add('partners_UserRealTime', datetime.now().isoformat())
+        add('partners_Deleted', "0")
+
+        add('users_ID', "2")
+        add('users_Code', "1")
+        add('users_Name', "Стефан")
+        add('users_Name2', "Стефан Радев")
+        add('users_IsVeryUsed', "-1")
+        add('users_GroupID', "2")
+        add('users_Password', "8KzKNOSLDSE=")
+        add('users_UserLevel', "3")
+        add('users_Deleted', "0")
+
+        add('currencies_ID', "1")
+        add('currencies_Currency', "BGN")
+        add('currencies_Description', "")
+        add('currencies_ExchangeRate', "1")
+        add('currencies_Deleted', "0")
+
+    # Типове плащания - фиксирани записи
+    pt1 = ET.SubElement(root, 'PaymentTypes')
+    ET.SubElement(pt1, 'paymentTypes_ID').text = '1'
+    ET.SubElement(pt1, 'paymentTypes_Name').text = 'Плащане в брой'
+    ET.SubElement(pt1, 'paymentTypes_PaymentMethod').text = '1'
+
+    pt2 = ET.SubElement(root, 'PaymentTypes')
+    ET.SubElement(pt2, 'paymentTypes_ID').text = '2'
+    ET.SubElement(pt2, 'paymentTypes_Name').text = 'Банков превод'
+    ET.SubElement(pt2, 'paymentTypes_PaymentMethod').text = '2'
+
+    pt3 = ET.SubElement(root, 'PaymentTypes')
+    ET.SubElement(pt3, 'paymentTypes_ID').text = '3'
+    ET.SubElement(pt3, 'paymentTypes_Name').text = 'Дебитна/Кредитна карта'
+    ET.SubElement(pt3, 'paymentTypes_PaymentMethod').text = '3'
+
+    pt4 = ET.SubElement(root, 'PaymentTypes')
+    ET.SubElement(pt4, 'paymentTypes_ID').text = '4'
+    ET.SubElement(pt4, 'paymentTypes_Name').text = 'Наложен платеж'
+    ET.SubElement(pt4, 'paymentTypes_PaymentMethod').text = '4'
+
     # Кратко описание
     desc = ET.SubElement(root, 'Description')
     ET.SubElement(desc, 'OperationRange').text = f"Проформи ОтДокумент № {ops_list[0]['invoice_no']} до {ops_list[-1]['invoice_no']}"

--- a/utils.py
+++ b/utils.py
@@ -175,10 +175,21 @@ def generate_transfer_log(ops_list, output_path):
     ET.SubElement(pt4, 'paymentTypes_Name').text = 'Наложен платеж'
     ET.SubElement(pt4, 'paymentTypes_PaymentMethod').text = '4'
 
+    pt5 = ET.SubElement(root, 'PaymentTypes')
+    ET.SubElement(pt5, 'paymentTypes_ID').text = '102'
+    ET.SubElement(pt5, 'paymentTypes_Name').text = 'ePay.bg'
+    ET.SubElement(pt5, 'paymentTypes_PaymentMethod').text = '2'
+
+    pt6 = ET.SubElement(root, 'PaymentTypes')
+    ET.SubElement(pt6, 'paymentTypes_ID').text = '103'
+    ET.SubElement(pt6, 'paymentTypes_Name').text = 'Плащане в брой (ЛЗН)'
+    ET.SubElement(pt6, 'paymentTypes_PaymentMethod').text = '1'
+
     # Кратко описание
     desc = ET.SubElement(root, 'Description')
-    ET.SubElement(desc, 'OperationRange').text = f"Проформи ОтДокумент № {ops_list[0]['invoice_no']} до {ops_list[-1]['invoice_no']}"
-    ET.SubElement(desc, 'UserName').text = "Стефан"  # <-- нов ред!
+    range_text = f"Проформи ОтДокумент № {ops_list[0]['invoice_no']} до {ops_list[-1]['invoice_no']}"
+    ET.SubElement(desc, 'OperationRange').text = range_text
+    ET.SubElement(desc, 'UserName').text = "Стефан"
     ET.SubElement(desc, 'ExportDate').text = datetime.now().strftime("%d.%m.%Y")
     ET.SubElement(desc, 'ExportTime').text = datetime.now().strftime("%H:%M")
     tree = ET.ElementTree(root)


### PR DESCRIPTION
## Summary
- include warehouse name from config when generating transfer log
- add config entries `object.id` and `object.name`
- include comprehensive OperationsRelated fields in transfer log and add PaymentTypes section

## Testing
- `python -m py_compile app.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688666ad837883209c87564481fdb0f2