### PR TITLE
Move sensitive user data to config

### DIFF
--- a/app.py
+++ b/app.py
@@ -345,7 +345,7 @@ def process_all(df, start_num, config, upload_folder):
 
     # Генериране на transfer.log
     transfer_log_path = os.path.join(upload_folder, 'transfer.log')
-    generate_transfer_log(transfer_ops, transfer_log_path)
+    generate_transfer_log(transfer_ops, transfer_log_path, config)
 
     return all_results, updated_df, transfer_log_path, doc_links
     

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -57,3 +57,12 @@ smtp:
   user: "user@example.com"
   password: "secret"
 
+microinvest_user:
+  id: 2
+  code: 1
+  name: "Стефан"
+  full_name: "Стефан Радев"
+  password: "8KzKNOSLDSE="
+  group_id: 2
+  user_level: 3
+

--- a/utils.py
+++ b/utils.py
@@ -29,37 +29,161 @@ def pdf_to_png(pdf_path, png_path):
     if images:
         images[0].save(png_path, "PNG")
 
-def generate_transfer_log(ops_list, output_path):
-    """
-    Създава transfer.log (XML) със списък от операции.
-    """
-    def to_int_str(val):
-        try:
-            return str(int(float(val)))
-        except (TypeError, ValueError):
-            return '0'
+def generate_transfer_log(ops_list, output_path, config):
+    """Създава transfer.log (XML) със списък от операции."""
+
+    user_cfg = config.get('microinvest_user', {})
+    user_id = str(user_cfg.get('id', 2))
+    user_code = str(user_cfg.get('code', 1))
+    user_name = user_cfg.get('name', '')
+    user_full_name = user_cfg.get('full_name', user_name)
+    user_password = user_cfg.get('password', '')
+    user_group_id = str(user_cfg.get('group_id', 2))
+    user_level = str(user_cfg.get('user_level', 3))
+
     root = ET.Element('Microinvest')
-    for op in ops_list:
+
+    for idx, op in enumerate(ops_list, start=1):
         oper = ET.SubElement(root, 'OperationsRelated')
-        ET.SubElement(oper, 'operations_ID').text = op['invoice_no']
-        ET.SubElement(oper, 'operations_OperType').text = "14"
-        ET.SubElement(oper, 'operations_Acct').text = op['invoice_no']
-        ET.SubElement(oper, 'operations_GoodID').text = to_int_str(op.get('code', 0))
-        ET.SubElement(oper, 'operations_PartnerID').text = to_int_str(op.get('partner_id', 0))
-        ET.SubElement(oper, 'operations_ObjectID').text = to_int_str(op.get('object_id', 0))
-        ET.SubElement(oper, 'operations_OperatorID').text = ""
-        ET.SubElement(oper, 'operations_Qtty').text = to_int_str(op.get('qty', 0))
-        ET.SubElement(oper, 'operations_PriceOut').text = op['price']
-        ET.SubElement(oper, 'operations_Date').text = datetime.now().isoformat()
-        ET.SubElement(oper, 'goods_Name').text = op['desc']
-        ET.SubElement(oper, 'objects_Name').text = op.get('object_name', '')
-        # Допиши и други полета ако трябва
-    # Кратко описание
+
+        def add(tag, value=""):
+            ET.SubElement(oper, tag).text = str(value)
+
+        add('operations_ID', f"{op['invoice_no']}{idx}")
+        add('operations_OperType', "14")
+        add('operations_Acct', op['invoice_no'])
+        add('operations_GoodID', op['code'])
+        add('operations_PartnerID', op.get('partner_id', ""))
+        add('operations_ObjectID', op.get('object_id', ""))
+        add('operations_OperatorID', "")
+        add('operations_Qtty', op['qty'])
+        add('operations_Sign', "0")
+        add('operations_PriceIn', "0")
+        add('operations_PriceOut', op['price'])
+        vat_out = "{:.2f}".format(float(op['price']) * 0.2)
+        add('operations_VATIn', "0")
+        add('operations_VATOut', vat_out)
+        add('operations_Discount', "0")
+        add('operations_CurrencyID', "1")
+        add('operations_Date', datetime.now().isoformat())
+        add('operations_Lot', " ")
+        add('operations_LotID', "1")
+        add('operations_Note', " ")
+        add('operations_SrcDocID', "0")
+        add('operations_UserID', user_id)
+        add('operations_UserRealTime', datetime.now().isoformat())
+
+        add('lots_ID', "1")
+        add('lots_SerialNo', "")
+        add('lots_Location', "")
+        add('lots_ProductionDate', "2002-01-01T00:00:00+02:00")
+        add('lots_EndDate', "2002-01-01T00:00:00+02:00")
+
+        add('goods_ID', op['code'])
+        add('goods_Code', op['code'])
+        add('goods_BarCode1', "")
+        add('goods_BarCode2', "")
+        add('goods_BarCode3', "")
+        add('goods_Catalog1', "")
+        add('goods_Catalog2', "")
+        add('goods_Catalog3', "")
+        add('goods_Name', op['desc'])
+        add('goods_Name2', op['desc'])
+        add('goods_Measure1', "бр.")
+        add('goods_Measure2', "бр.")
+        add('goods_Ratio', "1")
+        add('goods_PriceIn', "0")
+        add('goods_PriceOut1', "0")
+        add('goods_PriceOut2', op['price'])
+        for n in range(3, 11):
+            add(f'goods_PriceOut{n}', "0")
+        add('goods_MinQtty', "0")
+        add('goods_NormalQtty', "0")
+        add('goods_Description', "")
+        add('goods_Type', "0")
+        add('goods_IsRecipe', "0")
+        add('goods_TaxGroup', "1")
+        add('goods_IsVeryUsed', "0")
+        add('goods_GroupID', "502")
+        add('goods_Deleted', "0")
+
+        add('objects_ID', op.get('object_id', ""))
+        add('objects_Code', op.get('object_id', ""))
+        add('objects_Name', op.get('object_name', ""))
+        add('objects_Name2', op.get('object_name', ""))
+        add('objects_IsVeryUsed', "-1")
+        add('objects_GroupID', "1")
+        add('objects_PriceGroup', "1")
+        add('objects_Deleted', "0")
+
+        add('partners_ID', op.get('partner_id', ""))
+        add('partners_Code', "")
+        add('partners_Company', op['client'])
+        add('partners_Company2', op['client'])
+        add('partners_MOL', "")
+        add('partners_MOL2', "")
+        add('partners_City', "")
+        add('partners_City2', "")
+        add('partners_Address', "")
+        add('partners_Address2', "")
+        add('partners_Phone', "")
+        add('partners_Phone2', "")
+        add('partners_Fax', "")
+        add('partners_eMail', "")
+        add('partners_TaxNo', op.get('eik', ""))
+        add('partners_Bulstat', op.get('eik', ""))
+        add('Partners_BankName', "")
+        add('partners_BankCode', "")
+        add('partners_BankAcct', "")
+        add('partners_BankVATName', "")
+        add('partners_BankVATCode', "")
+        add('partners_BankVATAcct', "")
+        add('partners_PriceGroup', "1")
+        add('partners_Discount', "0")
+        add('partners_Type', "0")
+        add('partners_IsVeryUsed', "0")
+        add('partners_UserID', user_code)
+        add('partners_GroupID', "301")
+        add('partners_UserRealTime', datetime.now().isoformat())
+        add('partners_Deleted', "0")
+
+        add('users_ID', user_id)
+        add('users_Code', user_code)
+        add('users_Name', user_name)
+        add('users_Name2', user_full_name)
+        add('users_IsVeryUsed', "-1")
+        add('users_GroupID', user_group_id)
+        add('users_Password', user_password)
+        add('users_UserLevel', user_level)
+        add('users_Deleted', "0")
+
+        add('currencies_ID', "1")
+        add('currencies_Currency', "BGN")
+        add('currencies_Description', "")
+        add('currencies_ExchangeRate', "1")
+        add('currencies_Deleted', "0")
+
+    for pt_id, pt_name, pt_method in [
+        ('1', 'Плащане в брой', '1'),
+        ('2', 'Банков превод', '2'),
+        ('3', 'Дебитна/Кредитна карта', '3'),
+        ('4', 'Наложен платеж', '4'),
+        ('102', 'ePay.bg', '2'),
+        ('103', 'Плащане в брой (ЛЗН)', '1'),
+    ]:
+        pt = ET.SubElement(root, 'PaymentTypes')
+        ET.SubElement(pt, 'paymentTypes_ID').text = pt_id
+        ET.SubElement(pt, 'paymentTypes_Name').text = pt_name
+        ET.SubElement(pt, 'paymentTypes_PaymentMethod').text = pt_method
+
     desc = ET.SubElement(root, 'Description')
-    ET.SubElement(desc, 'OperationRange').text = f"Проформи ОтДокумент № {ops_list[0]['invoice_no']} до {ops_list[-1]['invoice_no']}"
-    ET.SubElement(desc, 'UserName').text = "Стефан"  # <-- нов ред!
+    ET.SubElement(desc, 'OperationRange').text = (
+        f"Проформи ОтДокумент № {ops_list[0]['invoice_no']} до {ops_list[-1]['invoice_no']}"
+    )
+    ET.SubElement(desc, 'UserName').text = user_name
     ET.SubElement(desc, 'ExportDate').text = datetime.now().strftime("%d.%m.%Y")
     ET.SubElement(desc, 'ExportTime').text = datetime.now().strftime("%H:%M")
+
     tree = ET.ElementTree(root)
     tree.write(output_path, encoding="utf-8", xml_declaration=True)
 


### PR DESCRIPTION
## Summary
- expand transfer log generation with detailed XML and move user fields to `config.example.yaml`
- adapt code to load Microinvest user data from config instead of hardcoding
- pass `config` to `generate_transfer_log`

## Testing
- `python -m py_compile utils.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_68867f01490483208bef304d5c8a7d72